### PR TITLE
[ bug-2813 -> master ] Adding getOrganizationsByUser function

### DIFF
--- a/src/services/organizationService.ts
+++ b/src/services/organizationService.ts
@@ -12,6 +12,10 @@ export class OrganizationService {
         return await this.connector.axios.get(`/organizations`, {baseURL: this.connector.config.baseURL});
     }
 
+    async getOrganizationsByUser(userId: string) {
+        return await this.connector.axios.get(`/organizations/user/${userId}`, {baseURL: this.connector.config.baseURL});
+    }
+
     async createOrganization(name: string, userIds: string[]) {
         const payload = {
             name, 


### PR DESCRIPTION
[Target Process](https://sevenhillstechnology.tpondemand.com/entity/2813)

To address the issue where all organizations are shown at the beginning of a survey, core connector has to have a route to return organizations by user.