### PR TITLE
[ us-3768 -> master ] setLoggedInUser can take null, remove internal redirectToLogin

### DIFF
--- a/src/components/authConnector.tsx
+++ b/src/components/authConnector.tsx
@@ -8,12 +8,11 @@ interface Props {
     loginUrl?: string;
     redirectToLogin?: boolean;
     reperioCoreConnector: ReperioCoreConnector;
-    setLoggedInUser: (user: User) => any;
+    setLoggedInUser: (user?: User) => any;
 }
 
 interface State {
     isInitialized: boolean;
-    redirectToLogin: boolean;
 }
 
 export class AuthConnector extends React.Component<Props, State> {
@@ -22,8 +21,7 @@ export class AuthConnector extends React.Component<Props, State> {
         super(props);
 
         this.state = {
-            isInitialized: false,
-            redirectToLogin: false
+            isInitialized: false
         };
     }
 
@@ -33,13 +31,12 @@ export class AuthConnector extends React.Component<Props, State> {
             const user = await this.props.reperioCoreConnector.authService.getLoggedInUser();
             this.props.setLoggedInUser(user);
             this.setState({
-                isInitialized: true,
-                redirectToLogin: false
+                isInitialized: true
             });
         } catch {
+            this.props.setLoggedInUser();
             this.setState({
-                isInitialized: true,
-                redirectToLogin: true
+                isInitialized: true
             });
         }
     }
@@ -49,7 +46,7 @@ export class AuthConnector extends React.Component<Props, State> {
             return null;
         }
 
-        const redirectToLogin = this.state.redirectToLogin || this.props.redirectToLogin;
+        const redirectToLogin = this.props.redirectToLogin;
         if (redirectToLogin) {
             if (this.props.loginUrl == null) {
                 return null;


### PR DESCRIPTION
Updates to new AuthConnector, removing internal `state.redirectToLogin` so that Managed IT (and other apps, as necessary) can have unauthenticated sessions without auto redirecting to login. Making the `user` property on `props.setLoggedInUser` nullable.